### PR TITLE
Use EntityId for performance

### DIFF
--- a/game-logic/src/entity.rs
+++ b/game-logic/src/entity.rs
@@ -2,8 +2,8 @@ mod enemy;
 mod entity_id;
 mod entity_set;
 mod projectile;
-mod temp_entity;
 mod ref_option;
+mod temp_entity;
 
 use core::f64;
 
@@ -12,8 +12,8 @@ pub use self::{
     entity_id::EntityId,
     entity_set::{EntityEntry, EntitySet},
     projectile::{BulletBase, Projectile},
+    ref_option::{RefMutOption, RefOption},
     temp_entity::{TempEntity, TempEntityType},
-    ref_option::{RefOption, RefMutOption},
 };
 #[cfg(all(not(feature = "webgl"), feature = "piston"))]
 use crate::assets_piston::Assets;
@@ -38,7 +38,6 @@ use web_sys::{WebGlRenderingContext as GL, WebGlTexture};
 
 /// The base structure of all Entities.  Implements common methods.
 pub struct Entity {
-    pub id: u32,
     pub pos: [f64; 2],
     pub velo: [f64; 2],
     pub health: i32,
@@ -74,10 +73,8 @@ where
 }
 
 impl Entity {
-    pub fn new(id_gen: &mut u32, pos: [f64; 2], velo: [f64; 2]) -> Self {
-        *id_gen += 1;
+    pub fn new(pos: [f64; 2], velo: [f64; 2]) -> Self {
         Self {
-            id: *id_gen,
             pos,
             velo,
             health: 1,

--- a/game-logic/src/entity.rs
+++ b/game-logic/src/entity.rs
@@ -1,13 +1,19 @@
 mod enemy;
+mod entity_id;
+mod entity_set;
 mod projectile;
 mod temp_entity;
+mod ref_option;
 
 use core::f64;
 
 pub use self::{
     enemy::{Enemy, EnemyBase, ShieldedBoss},
+    entity_id::EntityId,
+    entity_set::{EntityEntry, EntitySet},
     projectile::{BulletBase, Projectile},
     temp_entity::{TempEntity, TempEntityType},
+    ref_option::{RefOption, RefMutOption},
 };
 #[cfg(all(not(feature = "webgl"), feature = "piston"))]
 use crate::assets_piston::Assets;

--- a/game-logic/src/entity/entity_id.rs
+++ b/game-logic/src/entity/entity_id.rs
@@ -1,0 +1,67 @@
+use std::{fmt::Display, marker::PhantomData};
+
+use super::RefOption;
+
+pub struct EntityId<T> {
+    pub(super) id: u32,
+    pub(super) gen: u32,
+    _ph: PhantomData<fn(T)>,
+}
+
+impl<T> std::clone::Clone for EntityId<T> {
+    fn clone(&self) -> Self {
+        Self {
+            id: self.id,
+            gen: self.gen,
+            _ph: self._ph,
+        }
+    }
+}
+
+impl<T> std::marker::Copy for EntityId<T> {}
+
+impl<T> std::fmt::Debug for EntityId<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "EntityId({}, {})", self.id, self.gen)
+    }
+}
+
+impl<T> std::cmp::PartialEq for EntityId<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.id == other.id && self.gen == other.gen
+    }
+}
+
+impl<T> std::cmp::Eq for EntityId<T> {}
+
+impl<T> std::hash::Hash for EntityId<T> {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.id.hash(state);
+        self.gen.hash(state);
+    }
+}
+
+impl<T> EntityId<T> {
+    pub(super) fn new(id: u32, gen: u32) -> Self {
+        Self {
+            id,
+            gen,
+            _ph: PhantomData,
+        }
+    }
+}
+
+impl<T> Display for EntityId<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "({},{})", self.id, self.gen)
+    }
+}
+
+/// An extension trait to allow a container to iterate over valid items
+pub trait EntityIterExt<T> {
+    /// Iterate items in each entry's payload
+    #[allow(dead_code)]
+    fn items<'a>(&'a self) -> impl Iterator<Item = RefOption<'a, T>>
+    where
+        T: 'a;
+}

--- a/game-logic/src/entity/entity_set.rs
+++ b/game-logic/src/entity/entity_set.rs
@@ -1,0 +1,207 @@
+use std::cell::RefCell;
+
+use super::{EntityId, RefMutOption, RefOption};
+
+#[derive(Clone, PartialEq, Eq, Debug)]
+/// An entry in entity list with generational ids, with the payload and the generation
+pub struct EntityEntry<T> {
+    pub gen: u32,
+    pub payload: RefCell<Option<T>>,
+}
+
+impl<T> EntityEntry<T> {
+    pub(crate) fn new(payload: T) -> Self {
+        Self {
+            gen: 0,
+            payload: RefCell::new(Some(payload)),
+        }
+    }
+}
+
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct EntitySet<T> {
+    v: Vec<EntityEntry<T>>,
+}
+
+impl<T> EntitySet<T> {
+    pub fn new() -> Self {
+        Self { v: vec![] }
+    }
+
+    /// Returns the number of active elements in this EntitySet.
+    /// It does _not_ return the buffer length.
+    pub fn len(&self) -> usize {
+        // TODO: optimize by caching active elements
+        self.v
+            .iter()
+            .filter(|entry| entry.payload.borrow().is_some())
+            .count()
+    }
+
+    /// Return an iterator over Ref<T>.
+    /// It borrows the T immutably.
+    pub fn iter(&self) -> impl Iterator<Item = RefOption<T>> {
+        self.v.iter().filter_map(|v| RefOption::new(&v.payload))
+    }
+
+    /// Return an iterator over &mut T. It does not borrow the T with a RefMut,
+    /// because the self is already exclusively referenced.
+    pub fn iter_mut(&mut self) -> impl Iterator<Item = &mut T> {
+        self.v
+            .iter_mut()
+            .filter_map(|v| v.payload.get_mut().as_mut())
+    }
+
+    /// Return an iterator over RefMut<T>, skipping already borrowed items.
+    /// It borrows the T mutablly.
+    pub fn iter_borrow_mut(&self) -> impl Iterator<Item = RefMutOption<T>> {
+        self.v.iter().filter_map(|v| RefMutOption::new(&v.payload))
+    }
+
+    /// Return an iterator over (id, Ref<T>)
+    /// It is convenient when you want the EntityId of the iterated items.
+    /// It borrows the T immutably.
+    pub fn items(&self) -> impl Iterator<Item = (EntityId<T>, RefOption<T>)> {
+        self.v.iter().enumerate().filter_map(|(i, v)| {
+            Some((EntityId::new(i as u32, v.gen), RefOption::new(&v.payload)?))
+        })
+    }
+
+    /// Return an iterator over (id, &mut T).
+    /// It is convenient when you want the EntityId of the iterated items.
+    /// It does not borrow the T with a RefMut, because the self is already exclusively referenced.
+    pub fn items_mut(&mut self) -> impl Iterator<Item = (EntityId<T>, &mut T)> {
+        self.v.iter_mut().enumerate().filter_map(|(i, v)| {
+            Some((
+                EntityId::new(i as u32, v.gen),
+                v.payload.get_mut().as_mut()?,
+            ))
+        })
+    }
+
+    /// Return an iterator over (id, RefMut<T>), skipping already borrowed items.
+    /// It is convenient when you want the EntityId of the iterated items.
+    /// It borrows the T mutablly.
+    pub fn items_borrow_mut(&self) -> impl Iterator<Item = (EntityId<T>, RefMutOption<T>)> {
+        self.v.iter().enumerate().filter_map(|(i, v)| {
+            Some((
+                EntityId::new(i as u32, v.gen),
+                RefMutOption::new(&v.payload)?,
+            ))
+        })
+    }
+
+    // pub fn split_mid(&self, idx: usize) -> Option<(Ref<T>, &[EntityEntry<T>], &[EntityEntry<T>])> {
+    //     if self.v.len() <= idx {
+    //         return None;
+    //     }
+    //     let (first, mid) = self.v.split_at(idx);
+    //     let (center, last) = mid.split_first()?;
+    //     Some((center.payload.as_ref()?.try_borrow().ok()?, first, last))
+    // }
+
+    // pub fn split_mid_mut(&mut self, idx: usize) -> Option<(&mut T, EntitySliceMut<T>)> {
+    //     if self.v.len() <= idx {
+    //         return None;
+    //     }
+    //     let (first, mid) = self.v.split_at_mut(idx);
+    //     let (center, last) = mid.split_first_mut()?;
+    //     Some((center.payload.as_mut()?.get_mut(), EntitySliceMut([first, last])))
+    // }
+
+    pub fn insert(&mut self, val: T) -> EntityId<T> {
+        for (i, entry) in self.v.iter_mut().enumerate() {
+            let payload = entry.payload.get_mut();
+            if payload.is_none() {
+                entry.gen += 1;
+                entry.payload = RefCell::new(Some(val));
+                return EntityId::new(i as u32, entry.gen);
+            }
+        }
+        self.v.push(EntityEntry::new(val));
+        EntityId::new(self.v.len() as u32 - 1, 0)
+    }
+
+    pub fn remove(&mut self, id: EntityId<T>) -> Option<T> {
+        self.v.get_mut(id.id as usize).and_then(|entry| {
+            if id.gen == entry.gen {
+                entry.payload.get_mut().take()
+            } else {
+                None
+            }
+        })
+    }
+
+    // Will we need removal of an element through a shared reference? If so, we need `RefCell<Option<T>>`
+    // instead of `Option<RefCell<T>>`.
+    // pub fn borrow_remove(&self, id: EntityId) -> Option<T> {
+    //     self.v.get(id.id as usize).and_then(|entry| {
+    //         if id.gen == entry.gen {
+    //             entry.payload.borrow_mut().take().map(|v| v.into_inner())
+    //         } else {
+    //             None
+    //         }
+    //     })
+    // }
+
+    pub fn retain(&mut self, mut f: impl FnMut(&mut T) -> bool) {
+        for entry in &mut self.v {
+            let Some(payload) = entry.payload.get_mut().as_mut() else {
+                continue;
+            };
+            if !f(payload) {
+                entry.payload = RefCell::new(None);
+            }
+        }
+    }
+
+    pub fn retain_borrow_mut(&self, mut f: impl FnMut(&mut T, EntityId<T>) -> bool) {
+        for (id, entry) in self.v.iter().enumerate() {
+            let Ok(mut payload) = entry.payload.try_borrow_mut() else {
+                continue;
+            };
+            if payload.is_none() {
+                continue;
+            }
+            if !f(
+                payload.as_mut().unwrap(),
+                EntityId::new(id as u32, entry.gen),
+            ) {
+                *payload = None;
+            }
+        }
+    }
+
+    pub fn get(&self, id: EntityId<T>) -> Option<RefOption<T>> {
+        self.v.get(id.id as usize).and_then(|entry| {
+            if id.gen == entry.gen {
+                RefOption::new(&entry.payload)
+            } else {
+                None
+            }
+        })
+    }
+
+    pub fn get_mut(&mut self, id: EntityId<T>) -> Option<&mut T> {
+        self.v.get_mut(id.id as usize).and_then(|entry| {
+            if id.gen == entry.gen {
+                entry.payload.get_mut().as_mut()
+            } else {
+                None
+            }
+        })
+    }
+
+    /// Get without generation check
+    pub fn get_mut_at(&mut self, idx: usize) -> Option<&mut T> {
+        self.v
+            .get_mut(idx)
+            .and_then(|entry| entry.payload.get_mut().as_mut())
+    }
+
+    pub fn borrow_mut_at(&self, idx: usize) -> Option<RefMutOption<T>> {
+        self.v
+            .get(idx)
+            .and_then(|entry| RefMutOption::new(&entry.payload))
+    }
+}

--- a/game-logic/src/entity/ref_option.rs
+++ b/game-logic/src/entity/ref_option.rs
@@ -1,4 +1,7 @@
-use std::{cell::{Ref, RefCell, RefMut}, ops::{Deref, DerefMut}};
+use std::{
+    cell::{Ref, RefCell, RefMut},
+    ops::{Deref, DerefMut},
+};
 
 #[derive(Debug)]
 /// A wrapper around Ref<Option> that always has Some.

--- a/game-logic/src/entity/ref_option.rs
+++ b/game-logic/src/entity/ref_option.rs
@@ -1,0 +1,52 @@
+use std::{cell::{Ref, RefCell, RefMut}, ops::{Deref, DerefMut}};
+
+#[derive(Debug)]
+/// A wrapper around Ref<Option> that always has Some.
+/// We need a Ref to release the refcounter, but we would never return
+/// a Ref(None).
+pub struct RefOption<'a, T>(Ref<'a, Option<T>>);
+
+impl<'a, T> RefOption<'a, T> {
+    pub(super) fn new(val: &'a RefCell<Option<T>>) -> Option<Self> {
+        let v = val.try_borrow().ok()?;
+        if v.is_none() {
+            return None;
+        }
+        Some(Self(v))
+    }
+}
+
+impl<'a, T> Deref for RefOption<'a, T> {
+    type Target = T;
+    fn deref(&self) -> &Self::Target {
+        self.0.as_ref().unwrap()
+    }
+}
+
+/// A wrapper around RefMut<Option> that always has Some.
+/// We need a RefMut to release the refcounter, but we would never return
+/// a RefMut(None).
+pub struct RefMutOption<'a, T>(RefMut<'a, Option<T>>);
+
+impl<'a, T> RefMutOption<'a, T> {
+    pub(super) fn new(val: &'a RefCell<Option<T>>) -> Option<Self> {
+        let v = val.try_borrow_mut().ok()?;
+        if v.is_none() {
+            return None;
+        }
+        Some(Self(v))
+    }
+}
+
+impl<'a, T> Deref for RefMutOption<'a, T> {
+    type Target = T;
+    fn deref(&self) -> &Self::Target {
+        self.0.as_ref().unwrap()
+    }
+}
+
+impl<'a, T> DerefMut for RefMutOption<'a, T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.0.as_mut().unwrap()
+    }
+}

--- a/game-logic/src/lib.rs
+++ b/game-logic/src/lib.rs
@@ -95,7 +95,7 @@ pub struct ShooterState {
     pub enemies: EntitySet<Enemy>,
     pub items: Vec<Item>,
     pub bullets: EntitySet<Projectile>,
-    pub tent: Vec<TempEntity>,
+    pub tent: EntitySet<TempEntity>,
     pub rng: Xor128,
     pub shots_bullet: usize,
     pub shots_missile: usize,
@@ -115,7 +115,7 @@ impl Default for ShooterState {
             enemies: EntitySet::new(),
             items: vec![],
             bullets: EntitySet::new(),
-            tent: vec![],
+            tent: EntitySet::new(),
             rng: Xor128::new(3232132),
             shots_bullet: 0,
             shots_missile: 0,
@@ -573,18 +573,14 @@ impl ShooterState {
         if self.paused {
             return;
         }
-        let mut to_delete = vec![];
-        for (i, e) in &mut ((&mut self.tent).iter_mut().enumerate()) {
-            if !self.paused && e.animate_temp().is_some() {
-                to_delete.push(i);
-                continue;
+        let paused = self.paused;
+        self.tent.retain(|e| {
+            if !paused && e.animate_temp().is_some() {
+                //println!("Deleted tent {} / {}", *i, bullets.len());
+                return false;
             }
-        }
-
-        for i in to_delete.iter().rev() {
-            self.tent.remove(*i);
-            //println!("Deleted tent {} / {}", *i, bullets.len());
-        }
+            true
+        });
     }
 }
 

--- a/shooter-rust-native/src/main.rs
+++ b/shooter-rust-native/src/main.rs
@@ -34,13 +34,13 @@ fn main() -> Result<(), ShooterError> {
         let mut newvp = *viewport;
         newvp.window_size[0] = (wwidth as f64 * (vp_ratio / ratio).max(1.)) as u32;
         newvp.window_size[1] = (wheight as f64 * (ratio / vp_ratio).max(1.)) as u32;
-        #[cfg(debug_assertions)]
-        for (vp, name) in [(viewport, "Old"), (&newvp, "New")].iter() {
-            println!(
-                "{} Context: ratio: {} vp.rect: {:?} vp.draw: {:?} vp.window: {:?}",
-                name, ratio, vp.rect, vp.draw_size, vp.window_size
-            );
-        }
+        // #[cfg(debug_assertions)]
+        // for (vp, name) in [(viewport, "Old"), (&newvp, "New")].iter() {
+        //     println!(
+        //         "{} Context: ratio: {} vp.rect: {:?} vp.draw: {:?} vp.window: {:?}",
+        //         name, ratio, vp.rect, vp.draw_size, vp.window_size
+        //     );
+        // }
         newvp
     }
 
@@ -375,7 +375,7 @@ fn main() -> Result<(), ShooterError> {
                     };
                     ent = ent.health((max_frames * playback_rate) as i32);
 
-                    state.tent.push(TempEntity {
+                    state.tent.insert(TempEntity {
                         base: ent,
                         texture: match ty {
                             TT::Explode => assets.explode_tex.clone(),
@@ -389,7 +389,7 @@ fn main() -> Result<(), ShooterError> {
                             TT::Blood => 16,
                         },
                         playback_rate,
-                    })
+                    });
                 };
 
                 if !state.game_over && !state.paused {

--- a/shooter-rust-native/src/main.rs
+++ b/shooter-rust-native/src/main.rs
@@ -361,7 +361,6 @@ fn main() -> Result<(), ShooterError> {
                 // These variables are used in between multiple invocation of this closure.
                 let mut add_tent = |ty: TT, pos: &[f64; 2], state: &mut ShooterState| {
                     let mut ent = Entity::new(
-                        &mut state.id_gen,
                         [
                             pos[0] + 4. * (state.rng.gen() - 0.5),
                             pos[1] + 4. * (state.rng.gen() - 0.5),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -280,7 +280,7 @@ impl ShooterState {
                 };
                 ent = ent.health((max_frames * playback_rate * repeats) as i32);
 
-                state.tent.push(TempEntity {
+                state.tent.insert(TempEntity {
                     base: ent,
                     texture: match ty {
                         TT::Explode => assets.explode_tex.clone(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -266,7 +266,6 @@ impl ShooterState {
         let add_tent =
             |ty: TT, pos: &[f64; 2], velo: &[f64; 2], state: &mut game_logic::ShooterState| {
                 let mut ent = Entity::new(
-                    &mut state.id_gen,
                     [
                         pos[0] + 4. * (state.rng.gen() - 0.5),
                         pos[1] + 4. * (state.rng.gen() - 0.5),
@@ -406,6 +405,7 @@ impl ShooterState {
                                 LIGHTNING_VERTICES,
                                 &mut |state: &mut game_logic::ShooterState, segment: &[f64; 4]| {
                                     let b = [segment[2], segment[3]];
+                                    let mut res = true;
                                     for enemy in state.enemies.iter_mut() {
                                         let ebb = enemy.get_bb();
                                         if ebb[0] < b[0] + 4.
@@ -413,11 +413,14 @@ impl ShooterState {
                                             && ebb[1] < b[1] + 4.
                                             && b[1] - 4. <= ebb[3]
                                         {
-                                            add_tent(TempEntityType::Explode2, &b, &[0.; 2], state);
-                                            return false;
+                                            res = false;
+                                            break;
                                         }
                                     }
-                                    true
+                                    if !res {
+                                        add_tent(TempEntityType::Explode2, &b, &[0.; 2], state);
+                                    }
+                                    res
                                 },
                             );
                             let hit = length != LIGHTNING_VERTICES;


### PR DESCRIPTION
EntityId is the E in ECS, copied from [asteroid-colonies](https://github.com/msakuta/asteroid-colonies) implementation. It will reduce copies of data when an entity is deleted, thus is expected to improve the performance.

It has a little overhead in RefCell, but net benefit should be positive with large number of entities, since the move will cost O(n^2).
